### PR TITLE
Docker integration and example

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM debian:stretch-slim
+
+# install collectd
+RUN \
+    apt-get update -qq; \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -qq \
+        collectd \
+        libpython2.7 \
+        python-setuptools \
+        python-wheel \
+        python-pip; \
+    apt-get clean; \
+    rm -f /var/lib/apt/lists/deb* /var/lib/apt/lists/sec*
+
+
+RUN pip install fritzcollectd
+
+COPY entrypoint.sh /
+RUN chmod 755 /entrypoint.sh
+
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,30 @@
+# Docker Image
+
+## Building
+
+Just run inside of the `docker` directory
+
+```
+docker build -t fritzcollectd .
+```
+
+Afterwards, you can run it in debug to see if everything works as expected:
+
+```
+docker run -it --rm -e VERBOSE=true \
+  -e FRITZBOX_USER=<username> -e FRITZBOX_PASSWORD=<password> \
+  fritzcollectd
+```
+
+The output should show the values read from the FritzBox. The Docker image is templated via
+environment variables. For more information, please see `docker/entrypoint.sh`.
+
+## Test with `docker-compose`
+
+You can also spin up a whole Docker stack including InfluxDB and Grafana to play with:
+
+```
+FRITZBOX_USER=<username> FRITZBOX_PASSWORD=<password> docker-compose up --build -d
+```
+
+You can access the Grafana UI on `<your-docker-machine>:3000`, Chronograph runs on `:8888`.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,40 @@
+version: '3'
+
+services:
+
+  fritzcollectd:
+    build: .
+    hostname: fritzbox
+    depends_on:
+      - influxdb
+    environment:
+      - FRITZBOX_USER
+      - FRITZBOX_PASSWORD
+
+  influxdb:
+    build: influx-provisioning
+    environment:
+      - INFLUXDB_REPORTING_DISABLED=true
+
+  grafana:
+    build: grafana-provisioning
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ALERTING_ENABLED=false
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_BASIC_ENABLED=false
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_DISABLE_SIGNOUT_MENU=true
+    depends_on:
+      - influxdb
+
+  chronograf:
+    image: chronograf:alpine
+    command: --influxdb-url=http://influxdb:8086
+    ports:
+      - 8888:8888
+    depends_on:
+      - influxdb

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# access to InfluxDB
+INFLUXDB_HOST=${INFLUXDB_HOST:-influxdb}
+INFLUXDB_PORT=${INFLUXDB_PORT:-25826}
+
+# access to FritzBox
+FRITZBOX_HOST=${FRITZBOX_HOST:-fritz.box}
+FRITZBOX_PORT=${FRITZBOX_PORT:-49000}
+
+# reported hostname
+FRITZBOX_HOSTNAME=${FRITZBOX_HOSTNAME:fritzbox}
+
+# Plugin verbosity
+VERBOSE=${VERBOSE:-false}
+
+cat > /etc/collectd/collectd.conf <<EOF
+FQDNLookup true
+LoadPlugin logfile
+
+<Plugin logfile>
+    LogLevel "info"
+    File STDOUT
+    Timestamp true
+    PrintSeverity false
+</Plugin>
+
+LoadPlugin network
+LoadPlugin python
+
+<Plugin network>
+    Server "$INFLUXDB_HOST" "$INFLUXDB_PORT"
+</Plugin>
+<Plugin python>
+    Import "fritzcollectd"
+
+    <Module fritzcollectd>
+         Address "$FRITZBOX_HOST"
+         Port $FRITZBOX_PORT
+         User "$FRITZBOX_USER"
+         Password "$FRITZBOX_PASSWORD"
+         Hostname "$FRITZBOX_HOSTNAME"
+         Verbose "$VERBOSE"
+    </Module>
+</Plugin>
+EOF
+
+exec /usr/sbin/collectd -f

--- a/docker/grafana-provisioning/Dockerfile
+++ b/docker/grafana-provisioning/Dockerfile
@@ -1,0 +1,13 @@
+FROM grafana/grafana
+
+USER root
+
+COPY datasources /etc/grafana/provisioning/datasources/
+COPY dashboards /etc/grafana/provisioning/dashboards/
+
+RUN \
+    mkdir -p /var/lib/grafana/dashboards; \
+    curl https://grafana.com/api/dashboards/713/revisions/4/download > /var/lib/grafana/dashboards/713.json; \
+    sed -i -e 's/${DS_INFLUXDB_COLLECTD}/influxdb/g' /var/lib/grafana/dashboards/713.json
+
+USER grafana

--- a/docker/grafana-provisioning/dashboards/dashs.yaml
+++ b/docker/grafana-provisioning/dashboards/dashs.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+- name: 'default'
+  orgId: 1
+  folder: ''
+  type: file
+  disableDeletion: false
+  updateIntervalSeconds: 10 #how often Grafana will scan for changed dashboards
+  options:
+    path: /var/lib/grafana/dashboards

--- a/docker/grafana-provisioning/datasources/influx.yaml
+++ b/docker/grafana-provisioning/datasources/influx.yaml
@@ -1,0 +1,11 @@
+# config file version
+apiVersion: 1
+
+datasources:
+  - name: influxdb
+    type: influxdb
+    access: proxy
+    database: collectd
+    url: http://influxdb:8086
+    isDefault: true
+    editable: false

--- a/docker/influx-provisioning/Dockerfile
+++ b/docker/influx-provisioning/Dockerfile
@@ -1,0 +1,7 @@
+FROM docker_fritzcollectd
+
+FROM influxdb:alpine
+
+COPY --from=0 /usr/share/collectd/types.db /usr/share/collectd/types.db
+
+COPY influxdb.conf /etc/influxdb

--- a/docker/influx-provisioning/influxdb.conf
+++ b/docker/influx-provisioning/influxdb.conf
@@ -1,0 +1,21 @@
+[meta]
+  dir = "/var/lib/influxdb/meta"
+
+[data]
+  dir = "/var/lib/influxdb/data"
+  engine = "tsm1"
+  wal-dir = "/var/lib/influxdb/wal"
+
+[[collectd]]
+  enabled = true
+  bind-address = ":25826"
+  database = "collectd"
+  retention-policy = ""
+  batch-size = 5000
+  batch-pending = 10
+  batch-timeout = "10s"
+  read-buffer = 0
+  typesdb = "/usr/share/collectd/types.db"
+  security-level = "none"
+  auth-file = "/etc/collectd/auth_file"
+  parse-multivalue-plugin = "split"


### PR DESCRIPTION
The integration is based on fetzerch/fritzcollectd#14 with templated
variables.

An example of a complete Docker stack with fritzcollectd, influxdb,
grafana and chronograph is also available.