### PR TITLE
docker: Add Docker configuration

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,3 +23,16 @@ py36:
   script:
     - tox -e py36
   coverage: '/\S+\.py\s+(?:\d+\s+){4}(\d+\%)/'
+
+docker:
+  variables:
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: "/certs"
+  services:
+    - docker:dind
+  before_script:
+    - apk add --no-cache docker-compose
+  script:
+    - docker-compose -f docker/docker-compose.yml build
+  tags:
+    - docker-in-docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ jobs:
       env: TOXENV=py27
       install: pip install tox coveralls
       after_success: coveralls
+    - name: Docker
+      script: docker-compose -f docker/docker-compose.yml build
+      install: skip
+      services:
+        - docker
     - stage: deploy
       python: 3.5
       install: skip

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,11 @@ Please refer to the `project announcement blog post <https://fetzerch.github.io/
 for additional information, such as the usage of `Grafana <http://grafana.org>`__
 for metrics visualization.
 
+Docker Support
+--------------
+
+Please see the ``docker`` directory for running fritzcollectd via Docker.
+
 License
 -------
 This projected is licensed under the terms of the MIT license.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM alpine
+
+# Install collectd and dependencies for fritzcollectd.
+RUN apk add --no-cache \
+        collectd \
+        collectd-python \
+        collectd-network \
+        python2 \
+        py2-pip \
+        py2-lxml \
+        py2-pbr \
+        git
+
+# Copy entrypoint script.
+COPY entrypoint.sh /
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,43 @@
+# fritzcollectd - Docker Image
+
+This directory contains Docker support configuration for fritzcollectd.
+
+A `Dockerfile` simplifies the deployment of fritzcollectd for example into an
+existing environment with an already running Grafana and InfluxDB.
+
+In addition we also provide a `docker-compose.yaml` that allows to spin
+up Grafana, InfluxDB and collectd with the current development version
+of fritzcollectd.
+
+## Standalone Docker image
+
+The standalone Docker image is built with:
+
+```
+docker build -t fritzcollectd .
+```
+
+Afterwards the image can be run with:
+
+```
+docker run --rm \
+    --env FRITZBOX_HOST=<ip> \
+    --env FRITZBOX_USER=<username> \
+    --env FRITZBOX_PASSWORD=<password> \
+    --env VERBOSE=true \
+    fritzcollectd
+```
+
+The Docker image can be configured through environment variables.
+See `docker/entrypoint.sh` for more information.
+
+## Full Grafana, InfluxDB, collectd stack with `docker-compose`
+
+The following command allows to spin up a whole Docker based stack including
+a preconfigured Grafana and InfluxDB to play with:
+
+```
+FRITZBOX_USER=<username> FRITZBOX_PASSWORD=<password> docker-compose up --build --detach
+```
+
+You can access the Grafana UI on `<your-docker-host>:3000`.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3'
+
+services:
+  collectd:
+    build: .
+    environment:
+      - FRITZBOX_HOST
+      - FRITZBOX_PORT
+      - FRITZBOX_USER
+      - FRITZBOX_PASSWORD
+      - FRITZBOX_HOSTNAME
+      - INSTANCE
+      - VERBOSE
+    volumes:
+      # Mount development version of the plugin into the container.
+      - ..:/fritzcollectd:ro
+    depends_on:
+      - influxdb
+
+  grafana:
+    build: grafana-fritzcollectd
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_ANALYTICS_REPORTING_ENABLED=false
+      - GF_ALERTING_ENABLED=false
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_BASIC_ENABLED=false
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_AUTH_DISABLE_SIGNOUT_MENU=true
+    depends_on:
+      - influxdb
+
+  influxdb:
+    build: influxdb-collectd
+    environment:
+      - INFLUXDB_REPORTING_DISABLED=true

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# InfluxDB configuration.
+INFLUXDB_HOST=${INFLUXDB_HOST:-influxdb}
+INFLUXDB_PORT=${INFLUXDB_PORT:-25826}
+
+# fritzcollectd plugin configuration.
+FRITZBOX_HOST=${FRITZBOX_HOST:-fritz.box}
+FRITZBOX_PORT=${FRITZBOX_PORT:-49000}
+FRITZBOX_USER=${FRITZBOX_USER:-dslf-config}
+FRITZBOX_HOSTNAME=${FRITZBOX_HOSTNAME:-fritzbox}
+VERBOSE=${VERBOSE:-false}
+
+cat > /etc/collectd/collectd.conf <<EOF
+FQDNLookup true
+LoadPlugin logfile
+
+<Plugin logfile>
+    LogLevel "info"
+    File STDOUT
+    Timestamp true
+    PrintSeverity false
+</Plugin>
+
+LoadPlugin network
+LoadPlugin python
+
+<Plugin network>
+    Server "$INFLUXDB_HOST" "$INFLUXDB_PORT"
+</Plugin>
+<Plugin python>
+    ModulePath "/fritzcollectd"
+    Import "fritzcollectd"
+    LogTraces true
+
+    <Module fritzcollectd>
+        Address "$FRITZBOX_HOST"
+        Port $FRITZBOX_PORT
+        User "$FRITZBOX_USER"
+        Password "$FRITZBOX_PASSWORD"
+        Hostname "$FRITZBOX_HOSTNAME"
+        Instance "$INSTANCE"
+        Verbose "$VERBOSE"
+    </Module>
+</Plugin>
+EOF
+
+# This container supports running with fritzcollectd's git repository mounted
+# to /fritzcollectd (and we then just install the dependencies).
+if [ -d "/fritzcollectd" ]; then
+    pip install -r/fritzcollectd/requirements.txt
+else
+    pip install fritzcollectd
+fi
+
+exec /usr/sbin/collectd -f

--- a/docker/grafana-fritzcollectd/Dockerfile
+++ b/docker/grafana-fritzcollectd/Dockerfile
@@ -1,0 +1,13 @@
+FROM grafana/grafana
+
+# Provide Grafana provisioning configuration for datasources and dashboards.
+USER root
+COPY datasources /etc/grafana/provisioning/datasources/
+COPY dashboards /etc/grafana/provisioning/dashboards/
+
+# Download fritzcollectd dashboard.
+RUN mkdir -p /var/lib/grafana/dashboards; \
+    wget https://grafana.com/api/dashboards/713/revisions/4/download -O /var/lib/grafana/dashboards/713.json; \
+    sed -i -e 's/${DS_INFLUXDB_COLLECTD}/influxdb/g' /var/lib/grafana/dashboards/713.json
+
+USER grafana

--- a/docker/grafana-fritzcollectd/dashboards/dashboards.yaml
+++ b/docker/grafana-fritzcollectd/dashboards/dashboards.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+
+providers:
+  - name: default
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/docker/grafana-fritzcollectd/datasources/influxdb.yaml
+++ b/docker/grafana-fritzcollectd/datasources/influxdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: influxdb
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    database: collectd
+    isDefault: true

--- a/docker/influxdb-collectd/Dockerfile
+++ b/docker/influxdb-collectd/Dockerfile
@@ -1,0 +1,8 @@
+FROM influxdb:alpine
+
+# Enable InfluxDB's collectd listener.
+ENV INFLUXDB_COLLECTD_ENABLED=true
+
+# Download the collectd types collection.
+RUN mkdir -p /usr/share/collectd/types; \
+    wget https://raw.githubusercontent.com/collectd/collectd/master/src/types.db -O /usr/share/collectd/types.db


### PR DESCRIPTION
This PR adds Docker configuration for `fritzcollectd`. Thanks @redm123, @lnxbil.
I've mostly taken over your ideas with a few enhancements. Most noticeable is that when the image is used through `docker-compose.yml`, it's using the current development version (by mounting the python plugin file into the container). This helps me to quickly test changes to the plugin.

This closes  #26, #29, #14.