### PR TITLE
fritzcollectd: Add linkdownstreammax, linkupstreammax

### DIFF
--- a/fritzcollectd/__init__.py
+++ b/fritzcollectd/__init__.py
@@ -82,6 +82,11 @@ class FritzCollectd(object):
         (ServiceAction('LANEthernetInterfaceConfig:1', 'GetStatistics'),
          {'NewBytesSent': Value('lan_totalbytessent', 'bytes'),
           'NewBytesReceived': Value('lan_totalbytesreceived', 'bytes')}),
+        (ServiceAction('WANCommonInterfaceConfig:1',
+                       'GetCommonLinkProperties'),
+         {'NewLayer1DownstreamMaxBitRate':
+          Value('linkdownstreammax', 'bitrate'),
+          'NewLayer1UpstreamMaxBitRate': Value('linkupstreammax', 'bitrate')}),
         (ServiceAction('X_AVM-DE_Homeauto:1', 'GetGenericDeviceInfos',
                        'NewIndex', 'NewIndex', 'dect'),
          {'NewMultimeterPower': Value('power', 'power'),


### PR DESCRIPTION
This change adds two new measurements that indicate the maximum bitrates of the physical connection.

For example if you booked VDSL50, but your line is technically capable of higher bitrates, then {down,up}streammax are limited to 50/10. The new values would show for example 120/36.